### PR TITLE
Add vendor invoice sorting utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ Quickly build a high-error-correction QR code using the `qrcode` Python package.
 * Adjust `box_size`, `border`, or `error_correction` to tweak output quality.
 * Saves the generated PNG to `file_path`; point it at your preferred destination.
 
+### `vendor_invoice_sorter.py`
+Rules-driven sorter that shuttles PDF and Excel invoices into vendor folders.
+
+* Point `SOURCE_DIR` at the directory that holds newly downloaded invoices.
+* Populate `VENDOR_RULES` with `pattern: destination` mappings. Patterns are
+  evaluated in order; glob patterns (default) match via `fnmatch` and regex
+  patterns begin with `"re:"` and are matched case-insensitively.
+* Destination folders are created automatically beneath `SOURCE_DIR`.
+* Unmatched files are reported to stdout so you can extend `VENDOR_RULES`.
+* Preview the planned moves with:
+
+  ```bash
+  python vendor_invoice_sorter.py --dry-run
+  ```
+
+  Omit `--dry-run` to actually relocate the files.
+
 Dependencies are tracked in `requirements.txt`. It currently installs
 [`qrcode[pil]`](https://pypi.org/project/qrcode/) for `qrgenerator.py`; `mass_print.py`
 only needs the Python standard library on Windows. Install everything with:

--- a/vendor_invoice_sorter.py
+++ b/vendor_invoice_sorter.py
@@ -1,0 +1,108 @@
+"""Utilities for sorting vendor invoices into vendor-specific folders.
+
+This module looks for PDF or Excel files inside ``SOURCE_DIR`` and moves each
+file into the directory specified by the first matching rule from
+``VENDOR_RULES``.  A rule is expressed as a mapping of a filename pattern to a
+destination folder.  Patterns are evaluated in the order they are defined and
+may be either ``fnmatch`` glob patterns (default) or regular expressions when
+prefixed with ``"re:"``.  The optional ``--dry-run`` flag can be used to log
+the planned moves without modifying the filesystem.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import re
+import shutil
+from pathlib import Path
+from typing import Iterable
+
+# Directory that contains invoice files to classify.
+SOURCE_DIR = Path("/path/to/invoice/source")
+
+# Mapping of pattern -> destination directory (relative to SOURCE_DIR).
+#
+# Patterns prefixed with "re:" are treated as case-insensitive regular
+# expressions.  All other patterns are interpreted using fnmatch-style glob
+# semantics.  Destination folders are created on demand.
+VENDOR_RULES = {
+    # "*.acme_invoice.pdf": "AcmeCorp",
+    # "re:.*contoso.*\\.(pdf|xlsx?)$": "Contoso",
+}
+
+
+INVOICE_EXTENSIONS = {".pdf", ".xls", ".xlsx"}
+
+
+def iter_invoices(directory: Path) -> Iterable[Path]:
+    """Yield supported invoice files inside *directory* (non-recursively)."""
+
+    for candidate in directory.iterdir():
+        if candidate.is_file() and candidate.suffix.lower() in INVOICE_EXTENSIONS:
+            yield candidate
+
+
+def evaluate_rules(filename: str) -> tuple[str, Path] | tuple[None, None]:
+    """Return the first matching destination for *filename*.
+
+    The function respects the insertion order of ``VENDOR_RULES``.
+    """
+
+    for pattern, destination in VENDOR_RULES.items():
+        if pattern.startswith("re:"):
+            regex = pattern[3:]
+            if re.search(regex, filename, re.IGNORECASE):
+                return pattern, Path(destination)
+        else:
+            if fnmatch.fnmatch(filename, pattern):
+                return pattern, Path(destination)
+
+    return None, None
+
+
+def move_invoice(invoice: Path, destination: Path, dry_run: bool = False) -> None:
+    """Move *invoice* into *destination* (relative to SOURCE_DIR)."""
+
+    target_dir = SOURCE_DIR / destination
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_path = target_dir / invoice.name
+
+    if dry_run:
+        print(f"[DRY-RUN] Would move '{invoice}' -> '{target_path}'")
+        return
+
+    print(f"Moving '{invoice}' -> '{target_path}'")
+    shutil.move(str(invoice), str(target_path))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Sort vendor invoices by rule")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview planned moves without touching the filesystem.",
+    )
+    args = parser.parse_args()
+
+    if not SOURCE_DIR.exists():
+        raise SystemExit(f"SOURCE_DIR does not exist: {SOURCE_DIR}")
+
+    unmatched_files = []
+
+    for invoice in iter_invoices(SOURCE_DIR):
+        pattern, destination = evaluate_rules(invoice.name)
+        if destination is None:
+            unmatched_files.append(invoice)
+            continue
+
+        move_invoice(invoice, destination, dry_run=args.dry_run)
+
+    if unmatched_files:
+        print("\nUnmatched invoices:")
+        for invoice in unmatched_files:
+            print(f" - {invoice}")
+
+
+if __name__ == "__main__":
+    main()

--- a/vendor_invoice_sorter.py
+++ b/vendor_invoice_sorter.py
@@ -65,13 +65,13 @@ def move_invoice(invoice: Path, destination: Path, dry_run: bool = False) -> Non
     """Move *invoice* into *destination* (relative to SOURCE_DIR)."""
 
     target_dir = SOURCE_DIR / destination
-    target_dir.mkdir(parents=True, exist_ok=True)
     target_path = target_dir / invoice.name
 
     if dry_run:
         print(f"[DRY-RUN] Would move '{invoice}' -> '{target_path}'")
         return
 
+    target_dir.mkdir(parents=True, exist_ok=True)
     print(f"Moving '{invoice}' -> '{target_path}'")
     shutil.move(str(invoice), str(target_path))
 

--- a/vendor_invoice_sorter.py
+++ b/vendor_invoice_sorter.py
@@ -73,7 +73,7 @@ def move_invoice(invoice: Path, destination: Path, dry_run: bool = False) -> Non
 
     target_dir.mkdir(parents=True, exist_ok=True)
     print(f"Moving '{invoice}' -> '{target_path}'")
-    shutil.move(str(invoice), str(target_path))
+    shutil.move(invoice, target_path)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add a rule-driven invoice sorter script with glob/regex support and dry-run mode
- document configuration and usage guidance in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d6dd334f1883338ed9131a18c271c5